### PR TITLE
add opts.start and add support for empty start data and end date

### DIFF
--- a/example/data.js
+++ b/example/data.js
@@ -1,51 +1,51 @@
 var ganttData = [
 	{
 		id: 1, name: "Feature 1", series: [
-			{ name: "Planned", start: new Date(2010,00,01), end: new Date(2010,00,03) },
-			{ name: "Actual", start: new Date(2010,00,02), end: new Date(2010,00,05), color: "#f0f0f0" }
+			{ name: "Planned", start: new Date(2010,10,01), end: new Date(2010,10,02) },
+			{ name: "Actual", start: new Date(2010,10,02), end: new Date(2011,00,05), color: "#f0f0f0" }
 		]
 	}, 
 	{
 		id: 2, name: "Feature 2", series: [
-			{ name: "Planned", start: new Date(2010,00,05), end: new Date(2010,00,20) },
-			{ name: "Actual", start: new Date(2010,00,06), end: new Date(2010,00,17), color: "#f0f0f0" },
-			{ name: "Projected", start: new Date(2010,00,06), end: new Date(2010,00,17), color: "#e0e0e0" }
+			{ name: "Planned", start: new Date(2010,10,05), end: new Date(2011,00,20) },
+			{ name: "Actual", start: new Date(2010,10,06), end: new Date(2011,00,17), color: "#f0f0f0" },
+			{ name: "Projected", start: new Date(2010,10,06), end: new Date(2011,00,17), color: "#e0e0e0" }
 		]
 	}, 
 	{
 		id: 3, name: "Feature 3", series: [
-			{ name: "Planned", start: new Date(2010,00,11), end: new Date(2010,01,03) },
-			{ name: "Actual", start: new Date(2010,00,15), end: new Date(2010,01,03), color: "#f0f0f0" }
+			{ name: "Planned", start: new Date(2010,10,11), end: new Date(2011,01,03) },
+			{ name: "Actual", start: new Date(2010,10,15), end: new Date(2011,01,03), color: "#f0f0f0" }
 		]
 	}, 
 	{
 		id: 4, name: "Feature 4", series: [
-			{ name: "Planned", start: new Date(2010,01,01), end: new Date(2010,01,03) },
-			{ name: "Actual", start: new Date(2010,01,01), end: new Date(2010,01,05), color: "#f0f0f0" }
+			{ name: "Planned", start: new Date(2010,11,01), end: new Date(2011,01,03) },
+			{ name: "Actual", start: new Date(2010,11,01), end: new Date(2011,01,05), color: "#f0f0f0" }
 		]
 	},
 	{
 		id: 5, name: "Feature 5", series: [
-			{ name: "Planned", start: new Date(2010,02,01), end: new Date(2010,03,20) },
-			{ name: "Actual", start: new Date(2010,02,01), end: new Date(2010,03,26), color: "#f0f0f0" }
+			{ name: "Planned", start: new Date(2010,12,01), end: new Date(2011,03,20) },
+			{ name: "Actual", start: new Date(2010,12,01), end: new Date(2011,03,26), color: "#f0f0f0" }
 		]
 	}, 
 	{
 		id: 6, name: "Feature 6", series: [
-			{ name: "Planned", start: new Date(2010,00,05), end: new Date(2010,00,20) },
-			{ name: "Actual", start: new Date(2010,00,06), end: new Date(2010,00,17), color: "#f0f0f0" },
-			{ name: "Projected", start: new Date(2010,00,06), end: new Date(2010,00,20), color: "#e0e0e0" }
+			{ name: "Planned", start: new Date(2010,10,05), end: new Date(2011,00,20) },
+			{ name: "Actual", start: new Date(2010,10,06), end: new Date(2011,00,17), color: "#f0f0f0" },
+			{ name: "Projected", start: new Date(2010,10,06), end: new Date(2011,00,20), color: "#e0e0e0" }
 		]
 	}, 
 	{
 		id: 7, name: "Feature 7", series: [
-			{ name: "Planned", start: new Date(2010,00,11), end: new Date(2010,01,03) }
+			{ name: "Planned", start: new Date(2010,10,11), end: new Date(2011,01,03) }
 		]
 	}, 
 	{
 		id: 8, name: "Feature 8", series: [
-			{ name: "Planned", start: new Date(2010,01,01), end: new Date(2010,01,03) },
-			{ name: "Actual", start: new Date(2010,01,01), end: new Date(2010,01,05), color: "#f0f0f0" }
+			{ name: "Planned", start: new Date(2010,11,01), end: new Date(2011,01,03) },
+			{ name: "Actual", start: new Date(2010,11,01), end: new Date(2011,01,05), color: "#f0f0f0" }
 		]
 	}
 ];

--- a/example/data.js
+++ b/example/data.js
@@ -1,13 +1,13 @@
 var ganttData = [
 	{
 		id: 1, name: "Feature 1", series: [
-			{ name: "Planned", start: new Date(2010,10,01), end: new Date(2010,10,02) },
+			{ name: "Planned", start: "", end: "" },
 			{ name: "Actual", start: new Date(2010,10,02), end: new Date(2011,00,05), color: "#f0f0f0" }
 		]
 	}, 
 	{
 		id: 2, name: "Feature 2", series: [
-			{ name: "Planned", start: new Date(2010,10,05), end: new Date(2011,00,20) },
+			{ name: "Planned", start: "", end: "" },
 			{ name: "Actual", start: new Date(2010,10,06), end: new Date(2011,00,17), color: "#f0f0f0" },
 			{ name: "Projected", start: new Date(2010,10,06), end: new Date(2011,00,17), color: "#e0e0e0" }
 		]

--- a/example/index.html
+++ b/example/index.html
@@ -31,6 +31,7 @@
 			$("#ganttChart").ganttView({ 
 				data: ganttData,
 				slideWidth: 900,
+				start: new Date(2010,11,12),
 				behavior: {
 					onClick: function (data) { 
 						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy") + ", end: " + data.end.toString("M/d/yyyy") + " }";

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -11,6 +11,7 @@ showWeekends: boolean
 data: object
 cellWidth: number
 cellHeight: number
+start: date
 slideWidth: number
 dataUrl: string
 behavior: {
@@ -63,12 +64,11 @@ behavior: {
 		}
 
 		function build() {
-			
-			var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
-			var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
-			opts.start = startEnd[0];
-			opts.end = startEnd[1];
-			
+	            var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
+		    var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
+	            if (!opts.start) {opts.start = startEnd[0];}
+		    opts.end = startEnd[1];
+                    			
 	        els.each(function () {
 
 	            var container = jQuery(this);
@@ -223,8 +223,12 @@ behavior: {
                 for (var j = 0; j < data[i].series.length; j++) {
                     var series = data[i].series[j];
                     var size = DateUtils.daysBetween(series.start, series.end) + 1;
-					var offset = DateUtils.daysBetween(start, series.start);
-					var block = jQuery("<div>", {
+                    if (series.start >= start ) {
+                      var offset = DateUtils.daysBetween(start, series.start);                                           
+                    } else {
+                      var offset = -(DateUtils.daysBetween(series.start, start));
+                    }                    
+                    var block = jQuery("<div>", {
                         "class": "ganttview-block",
                         "title": series.name + ", " + size + " days",
                         "css": {

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -64,11 +64,11 @@ behavior: {
 		}
 
 		function build() {
-	            var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
-		    var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
-	            if (!opts.start) {opts.start = startEnd[0];}
-		    opts.end = startEnd[1];
-                    			
+	        var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
+	        var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
+	        if (!opts.start) {opts.start = startEnd[0];}
+	        opts.end = startEnd[1];
+
 	        els.each(function () {
 
 	            var container = jQuery(this);
@@ -222,26 +222,29 @@ behavior: {
             for (var i = 0; i < data.length; i++) {
                 for (var j = 0; j < data[i].series.length; j++) {
                     var series = data[i].series[j];
-                    var size = DateUtils.daysBetween(series.start, series.end) + 1;
-                    if (series.start >= start ) {
-                      var offset = DateUtils.daysBetween(start, series.start);                                           
-                    } else {
-                      var offset = -(DateUtils.daysBetween(series.start, start));
-                    }                    
-                    var block = jQuery("<div>", {
-                        "class": "ganttview-block",
-                        "title": series.name + ", " + size + " days",
-                        "css": {
-                            "width": ((size * cellWidth) - 9) + "px",
-                            "margin-left": ((offset * cellWidth) + 3) + "px"
-                        }
-                    });
-                    addBlockData(block, data[i], series);
-                    if (data[i].series[j].color) {
-                        block.css("background-color", data[i].series[j].color);
+                    if (series.start != "" && series.end != "" && Date.parse(series.end) >= start) {
+                      var size = DateUtils.daysBetween(series.start, series.end) + 1;
+                      var series_start = Date.parse(series.start);
+                      if (series_start >= start ) {
+                        var offset = DateUtils.daysBetween(start, series_start);
+                      } else {
+                        var offset = -(DateUtils.daysBetween(series_start, start));
+                      }
+                      var block = jQuery("<div>", {
+                          "class": "tooltip ganttview-block",
+                          "title": series.name + ", " + size + " days",
+                          "css": {
+                              "width": ((size * cellWidth) - 9) + "px",
+                              "margin-left": ((offset * cellWidth) + 3) + "px"
+                          }
+                      });
+                      addBlockData(block, data[i], series);
+                      if (data[i].series[j].color) {
+                          block.css("background-color", data[i].series[j].color);
+                      }
+                      block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                      jQuery(rows[rowIdx]).append(block);
                     }
-                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-                    jQuery(rows[rowIdx]).append(block);
                     rowIdx = rowIdx + 1;
                 }
             }
@@ -368,11 +371,13 @@ behavior: {
 			var minStart = new Date(); maxEnd = new Date();
 			for (var i = 0; i < data.length; i++) {
 				for (var j = 0; j < data[i].series.length; j++) {
-					var start = Date.parse(data[i].series[j].start);
-					var end = Date.parse(data[i].series[j].end)
-					if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
-					if (minStart.compareTo(start) == 1) { minStart = start; }
-					if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
+				  if (data[i].series[j].start != "" && data[i].series[j].end != "") {
+				    var start = Date.parse(data[i].series[j].start);
+				    var end = Date.parse(data[i].series[j].end);
+				    if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
+				    if (minStart.compareTo(start) == 1) { minStart = start; }
+				    if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
+				  }
 				}
 			}
 			


### PR DESCRIPTION
hi,

i've been using your plugin on our project.
in our project we need opts.start. 
so we are hiding block if series.date < opts.start to increase performance

also there are some series with empty start and end date (so gantt only display series name).
to increase performance, we don't add block data if start date and end date are empty.

maybe you like our patches.

btw, nice plugin
thank you for your effort to make jQuery.ganttView
