### PR TITLE
Add fonctionnality groupBySeries and groupById

### DIFF
--- a/example/data.js
+++ b/example/data.js
@@ -6,14 +6,14 @@ var ganttData = [
 		]
 	}, 
 	{
-		id: 2, name: "Feature 2", series: [
+		id: 1, name: "Feature 2", series: [
 			{ name: "Planned", start: new Date(2010,00,05), end: new Date(2010,00,20) },
 			{ name: "Actual", start: new Date(2010,00,06), end: new Date(2010,00,17), color: "#f0f0f0" },
 			{ name: "Projected", start: new Date(2010,00,06), end: new Date(2010,00,17), color: "#e0e0e0" }
 		]
 	}, 
 	{
-		id: 3, name: "Feature 3", series: [
+		id: 1, name: "Feature 3", series: [
 			{ name: "Planned", start: new Date(2010,00,11), end: new Date(2010,01,03) },
 			{ name: "Actual", start: new Date(2010,00,15), end: new Date(2010,01,03), color: "#f0f0f0" }
 		]

--- a/example/index.html
+++ b/example/index.html
@@ -31,6 +31,9 @@
 			$("#ganttChart").ganttView({ 
 				data: ganttData,
 				slideWidth: 900,
+				groupBySeries: true,
+				groupById: true,
+				groupByIdDrawAllTitles: true,
 				behavior: {
 					onClick: function (data) { 
 						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy") + ", end: " + data.end.toString("M/d/yyyy") + " }";

--- a/jquery.ganttView.css
+++ b/jquery.ganttView.css
@@ -91,7 +91,7 @@ div.ganttview-slide-container {
 
 div.ganttview-grid-row-cell {
 	width: 20px;
-	height: 31px;
+	height: 100%;
 	border-right: 1px solid #f0f0f0;
 	border-top: 1px solid #f0f0f0;
 }
@@ -105,21 +105,35 @@ div.ganttview-grid-row-cell.ganttview-weekend {
 
 div.ganttview-blocks {
 	margin-top: 40px;
+  opacity: 0.8;
+}
+
+div.ganttview-block:hover {
+  z-index: 9999;
+  opacity: 1;
 }
 
 div.ganttview-block-container {
 	height: 28px;
 	padding-top: 4px;
+    position: relative;
 }
 
 div.ganttview-block {
-	position: relative;
+	position: absolute;
+	margin-top: 4px;
 	height: 25px;
 	background-color: #E5ECF9;
 	border: 1px solid #c0c0c0;
 	border-radius: 3px;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;
+	opacity: 0.8;
+}
+
+div.ganttview-block:hover {
+	z-index: 9999;
+	opacity: 1;
 }
 
 div.ganttview-block-text {


### PR DESCRIPTION
Hey,
To keep my master equals to upstream, I created a new branch for this feature and I clean it to minimize modification (indent, ...)
So, I will close PR https://github.com/thegrubbsian/jquery.ganttView/pull/26
Feature:

- groupBySeries permit to aggregate all elements in the serie to the same row
- groupById permit to aggregate all rows with the same id to an uniq row.
- Add opacity for not hover element"
- Add option groupByIdDrawAllTitles: This option permit to draw all titles
- when the option groupById is enabled else draw only the first title
- When groupByIdDrawAllTitles is enabled, cellHeight is auto sized